### PR TITLE
[CFDP-459-453] Hide Schedules Fix and add 'Get Started' label

### DIFF
--- a/src/data-mocks/event-connected.js
+++ b/src/data-mocks/event-connected.js
@@ -158,6 +158,31 @@ export const TEST_EVENT_JSON = {
     ]
 }
 
+export const EMPTY_SCHEDULE_EVENT = {
+    "id": "EventContentItem:7599c1977d3e517b75adeebc411d51ed",
+    "title": "Vision Weekend",
+    "summary": "The Movement is Now",
+    "htmlContent": "<p>It's a movement of miracles</p><p>It's a movement of freedom</p><p>It's a movement of restoration</p><p>It's a movement of Impact</p><p>It's a movement of life change</p><p>It's a movement of new beginnings</p><p>It's a movement of hope</p><p>It's a movement of God</p><p><br /></p>",
+    "coverImage": {
+        "name": "Image",
+        "sources": [
+            {
+                "uri": "https://cloudfront.christfellowship.church/GetImage.ashx?guid=cb136dd3-83d9-41ae-912a-53266646edaf"
+            }
+        ]
+    },
+    "tags": [
+        "Vision"
+    ],
+    "callsToAction": [{
+        "call": "Register Here",
+        "action": "/#"
+    }],
+    "openLinksInNewTab": false,
+    "events": [
+    ]
+}
+
 export const EVENT_MOCK = {
     request: {
         query: GET_EVENT,

--- a/src/events/EventDetail.js
+++ b/src/events/EventDetail.js
@@ -63,7 +63,7 @@ const EventDetail = ({
             className="py-3"
           >
             <h3 className='text-dark'>
-              Event Details
+              Details
             </h3>
             <div className='mb-5'>
               {htmlToReactParser.parse(htmlContent)}

--- a/src/events/EventSchedule.js
+++ b/src/events/EventSchedule.js
@@ -171,6 +171,13 @@ const EventSchedule = ({
     setVisibleOccurrences(campusEvents)
   }
 
+  //if array is empty set to default button
+  if(callsToAction.length < 1){
+    callsToAction = [{
+      call: 'Register',
+      action: '/#'
+    }]
+  }
 
   return (
     <>
@@ -262,12 +269,15 @@ EventSchedule.propTypes = {
       call: PropTypes.string,
       action: PropTypes.string,
     })
-  )
+  ).isRequired
 }
 
 EventSchedule.defaultProps = {
   defaultCampus: '',
-  callsToAction: []
+  callsToAction: [{
+    call:'Register',
+    action: '/#'
+  }]
 }
 
 export default EventSchedule

--- a/src/events/EventSchedule.js
+++ b/src/events/EventSchedule.js
@@ -171,6 +171,7 @@ const EventSchedule = ({
     setVisibleOccurrences(campusEvents)
   }
 
+  //NOTE** would like to fix to use defaultProps instead in the future. As of now doesn't read empty arrays.
   //if array is empty set to default button
   if(callsToAction.length < 1){
     callsToAction = [{

--- a/src/events/EventSchedule.js
+++ b/src/events/EventSchedule.js
@@ -148,6 +148,8 @@ const EventSchedule = ({
   events,
 }) => {
   const [visibleOccurrences, setVisibleOccurrences] = useState([])
+  const noEvents = events.length < 1
+
   const campusOptions = uniq(flatMapDepth(
     events.map(e => e.campuses.map(c => c.name)),
     identity,
@@ -169,11 +171,10 @@ const EventSchedule = ({
     setVisibleOccurrences(campusEvents)
   }
 
-  const noCampuses = campusOptions.length < 1
 
   return (
     <>
-    {!noCampuses &&
+    {!noEvents &&
       <CampusSelection
         key={`CampusSelection`}
         campuses={campusOptions}
@@ -181,75 +182,74 @@ const EventSchedule = ({
         defaultCampus={defaultCampus}
       />
     }
-
-    <Card
-      key={`EventOccurences`}
-      className={classnames(
-        'mb-3',
-      )}
-    >
-      <div className="py-3">
-        {groupByLocationDate.map((event, i) => {
-          const { location, dateTimes } = event
-          return <div
-            key={`EventOccurence:${i}`}
-            className={classnames({
-              'border-bottom': i < groupByLocationDate.length - 1,
-              'border-light': i < groupByLocationDate.length - 1,
-              'mb-3': i < groupByLocationDate.length - 1,
-            })}
-          >
-            {keys(dateTimes).map(date => (
-              <EventTimes
-                key={`EventOccurenceDate:${date}`}
-                date={date}
-                times={dateTimes[date]}
+       <Card
+          key={`EventOccurences`}
+          className={classnames(
+            'mb-3',
+          )}
+        >
+          <div className="py-3">
+            {groupByLocationDate.map((event, i) => {
+              const { location, dateTimes } = event
+              return <div
+                key={`EventOccurence:${i}`}
                 className={classnames({
-                  'mb-4': keys(dateTimes).length > 1,
+                  'border-bottom': i < groupByLocationDate.length - 1,
+                  'border-light': i < groupByLocationDate.length - 1,
+                  'mb-3': i < groupByLocationDate.length - 1,
                 })}
-              />
-            ))}
-
-            <div className="my-3">
-              <h4
-                className='mb-2'
               >
-                Address
-              </h4>
-              <a
-                className="text-dark"
-                href={getDirectionsUrl(location)}
-                target="_blank"
-              >
-                {location}
-              </a>
+                {keys(dateTimes).map(date => (
+                  <EventTimes
+                    key={`EventOccurenceDate:${date}`}
+                    date={date}
+                    times={dateTimes[date]}
+                    className={classnames({
+                      'mb-4': keys(dateTimes).length > 1,
+                    })}
+                  />
+                ))}
+    
+                <div className="my-3">
+                  <h4
+                    className='mb-2'
+                  >
+                    Address
+                  </h4>
+                  <a
+                    className="text-dark"
+                    href={getDirectionsUrl(location)}
+                    target="_blank"
+                  >
+                    {location}
+                  </a>
+                </div>
+              </div>
+            })}
+    
+              {!!noEvents && callsToAction.length > 0 &&
+                <h3 className='mb-n4'>Get Started</h3>
+              }
+    
+            <div className={classnames({ 'mt-5': callsToAction.length > 0 })}>
+              {callsToAction.map((n, i) => (
+                <a
+                  key={i}
+                  className={classnames(
+                    'btn',
+                    'btn-primary',
+                    'btn-block',
+                    "my-3"
+                  )}
+                  href={n.action}
+                  target={openLinksInNewTab ? '_blank' : ''}
+                >
+                  {n.call}
+                </a>
+              ))}
             </div>
           </div>
-        })}
-
-          {!!noCampuses &&
-            <h3 className='mb-n4'>Get Started</h3>
-          }
-
-        <div className={classnames({ 'mt-5': callsToAction.length > 0 })}>
-          {callsToAction.map((n, i) => (
-            <a
-              key={i}
-              className={classnames(
-                'btn',
-                'btn-primary',
-                'btn-block',
-                "my-3"
-              )}
-              href={n.action}
-              target={openLinksInNewTab ? '_blank' : ''}
-            >
-              {n.call}
-            </a>
-          ))}
-        </div>
-      </div>
-    </Card >
+        </Card > 
     </>
   )
 }

--- a/src/events/EventSchedule.js
+++ b/src/events/EventSchedule.js
@@ -107,6 +107,8 @@ const CampusSelection = ({ campuses, onChange, defaultCampus }) => {
   // when the selection changes, call the onChange method
   useEffect(() => onChange(selected), [selected])
 
+  
+
   return <Card className="mb-3">
     <Dropdown
       id={id}
@@ -167,17 +169,23 @@ const EventSchedule = ({
     setVisibleOccurrences(campusEvents)
   }
 
-  return [
-    <CampusSelection
-      key={`CampusSelection`}
-      campuses={campusOptions}
-      onChange={onChange}
-      defaultCampus={defaultCampus}
-    />,
+  const noCampuses = campusOptions.length < 1
+
+  return (
+    <>
+    {!noCampuses &&
+      <CampusSelection
+        key={`CampusSelection`}
+        campuses={campusOptions}
+        onChange={onChange}
+        defaultCampus={defaultCampus}
+      />
+    }
+
     <Card
       key={`EventOccurences`}
       className={classnames(
-        'my-3',
+        'mb-3',
       )}
     >
       <div className="py-3">
@@ -219,6 +227,10 @@ const EventSchedule = ({
           </div>
         })}
 
+          {!!noCampuses &&
+            <h3 className='mb-n4'>Get Started</h3>
+          }
+
         <div className={classnames({ 'mt-5': callsToAction.length > 0 })}>
           {callsToAction.map((n, i) => (
             <a
@@ -238,7 +250,8 @@ const EventSchedule = ({
         </div>
       </div>
     </Card >
-  ]
+    </>
+  )
 }
 
 EventSchedule.propTypes = {

--- a/src/events/__tests__/EventSchedule.tests.js
+++ b/src/events/__tests__/EventSchedule.tests.js
@@ -6,7 +6,7 @@ import { AuthProvider } from '../../auth'
 import EventSchedule from '../EventSchedule'
 import { Events } from '../../data-mocks'
 
-const { TEST_EVENT_JSON } = Events
+const { TEST_EVENT_JSON, EMPTY_SCHEDULE_EVENT } = Events
 
 let component = null
 
@@ -17,8 +17,18 @@ describe('EventSchedule', () => {
                 <EventSchedule {...TEST_EVENT_JSON} />
             </AuthProvider>
         )
+        const { container } = component
+        expect(container).toMatchSnapshot()
+    })
 
+    it("renders an empty schedule with Get Started Label and call to action", async () => {
+        component = render(
+            <AuthProvider>
+                <EventSchedule {...EMPTY_SCHEDULE_EVENT} />
+            </AuthProvider>
+        )
         const { container } = component
         expect(container).toMatchSnapshot()
     })
 })
+

--- a/src/events/__tests__/__snapshots__/EventDetail.tests.js.snap
+++ b/src/events/__tests__/__snapshots__/EventDetail.tests.js.snap
@@ -55,7 +55,7 @@ exports[`EventDetail renders Event Details 1`] = `
           </div>
         </div>
         <div
-          class="card border-0 shadow my-3"
+          class="card border-0 shadow mb-3"
         >
           <div
             class="card-body"

--- a/src/events/__tests__/__snapshots__/EventSchedule.tests.js.snap
+++ b/src/events/__tests__/__snapshots__/EventSchedule.tests.js.snap
@@ -1,5 +1,38 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`EventSchedule renders an empty schedule 1`] = `
+<div>
+  <div
+    class="card border-0 shadow mb-3"
+  >
+    <div
+      class="card-body"
+    >
+      <div
+        class="py-3"
+      >
+        <h3
+          class="mb-n4"
+        >
+          Get Started
+        </h3>
+        <div
+          class="mt-5"
+        >
+          <a
+            class="btn btn-primary btn-block my-3"
+            href="/#"
+            target=""
+          >
+            Register Here
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`EventSchedule renders the schedule of an event 1`] = `
 <div>
   <div

--- a/src/events/__tests__/__snapshots__/EventSchedule.tests.js.snap
+++ b/src/events/__tests__/__snapshots__/EventSchedule.tests.js.snap
@@ -46,7 +46,7 @@ exports[`EventSchedule renders the schedule of an event 1`] = `
     </div>
   </div>
   <div
-    class="card border-0 shadow my-3"
+    class="card border-0 shadow mb-3"
   >
     <div
       class="card-body"

--- a/src/router/Events/__tests__/__snapshots__/EventConnected.tests.js.snap
+++ b/src/router/Events/__tests__/__snapshots__/EventConnected.tests.js.snap
@@ -111,7 +111,7 @@ exports[`EventConnected renders an event 1`] = `
           </div>
         </div>
         <div
-          class="card border-0 shadow my-3"
+          class="card border-0 shadow mb-3"
         >
           <div
             class="card-body"


### PR DESCRIPTION
## Events Update
* The Campus Selector will now hide if no schedules are set to an Event
* A "Get Started" label will appear above CallToAction if no schedules are set in Rock.