### PR TITLE
[CFDP-512] Added CardFeedWithRouter

### DIFF
--- a/src/features-feed/ActionMapper.js
+++ b/src/features-feed/ActionMapper.js
@@ -1,22 +1,22 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-import { uniq, take, kebabCase } from 'lodash';
+import React from 'react'
+import PropTypes from 'prop-types'
+import { uniq, take, kebabCase } from 'lodash'
 
-import classnames from 'classnames';
-import { CardFeed } from '../content-feed';
-import ContentCardConnected from '../content-card-connected';
+import classnames from 'classnames'
+import { CardFeed } from '../content-feed'
+import ContentCardConnected from '../content-card-connected'
 import {
     AnnouncementFeed, TileRowCardFeed, CardRow, ChildrenFeed,
-} from './Features';
-import { ContentCard } from '../ui';
-import { CARD_PADDING, MARGIN_Y, FeatureSection } from '.';
+} from './Features'
+import { ContentCard } from '../ui'
+import { CARD_PADDING, MARGIN_Y, FeatureSection } from '.'
 
 const ACTION_TYPES = {
     event: 'READ_EVENT',
     content: 'READ_CONTENT',
     global: 'READ_GLOBAL_CONTENT',
     children: 'VIEW_CHILDREN',
-};
+}
 
 const ActionMapper = ({
     title,
@@ -24,7 +24,7 @@ const ActionMapper = ({
     image,
     isLoading,
 }) => {
-    const actionTypes = uniq(actions.map(({ action }) => action));
+    const actionTypes = uniq(actions.map(({ action }) => action))
 
     if (actionTypes.length === 1 && actionTypes.includes(ACTION_TYPES.event)) {
         // When the only action is to view Events
@@ -36,7 +36,7 @@ const ActionMapper = ({
                     actions={take(actions, 4)}
                 />
             </FeatureSection>
-        );
+        )
     } if (actionTypes.length === 1 && actionTypes.includes(ACTION_TYPES.content)) {
         // When the only action is to view Content
         return (
@@ -47,12 +47,12 @@ const ActionMapper = ({
                     isLoading={isLoading}
                 />
             </FeatureSection>
-        );
+        )
     }
 
     return actions.map(({ title: actionTitle, action, relatedNode }, i) => {
-        const key = `ActionMapper:${i}`;
-        let CardType = null;
+        const key = `ActionMapper:${i}`
+        let CardType = null
 
         switch (action) {
             case ACTION_TYPES.global:
@@ -63,7 +63,7 @@ const ActionMapper = ({
                             itemId={relatedNode.id}
                         />
                     </FeatureSection>
-                );
+                )
             case ACTION_TYPES.children:
                 return (
                     <FeatureSection key={key}>
@@ -72,13 +72,13 @@ const ActionMapper = ({
                             connection="child"
                             title={actionTitle}
                             first={3}
-                            urlBase="browse"
+                            urlBase={`content/collection/${kebabCase(actionTitle)}-${relatedNode.id.split(':').pop()}`}
                         />
                     </FeatureSection>
-                );
+                )
             default:
-                CardType = ContentCard;
-                break;
+                CardType = ContentCard
+                break
         }
 
         return !!CardType && (
@@ -98,20 +98,20 @@ const ActionMapper = ({
                     </div>
                 </div>
             </FeatureSection>
-        );
-    });
-};
+        )
+    })
+}
 
 ActionMapper.propTypes = {
     title: PropTypes.string,
     subtitle: PropTypes.string,
     actions: PropTypes.array,
     isLoading: PropTypes.bool,
-};
+}
 
 ActionMapper.defaultProps = {
     title: '',
     actions: [],
-};
+}
 
-export default ActionMapper;
+export default ActionMapper

--- a/src/features-feed/ActionMapper.js
+++ b/src/features-feed/ActionMapper.js
@@ -72,7 +72,10 @@ const ActionMapper = ({
                             connection="child"
                             title={actionTitle}
                             first={3}
-                            urlBase={`content/collection/${kebabCase(actionTitle)}-${relatedNode.id.split(':').pop()}`}
+                            urlBase={actionTitle === 'Popular Now'
+                                ? 'browse'
+                                : `content/collection/${kebabCase(actionTitle)}-${relatedNode.id.split(':').pop()}`
+                            }
                         />
                     </FeatureSection>
                 )

--- a/src/router/Content/index.js
+++ b/src/router/Content/index.js
@@ -1,34 +1,66 @@
-import React from 'react';
+import React from 'react'
 import {
     Switch, Route, Redirect,
-} from 'react-router-dom';
-import { useQuery } from 'react-apollo';
-import { get, last } from 'lodash';
+} from 'react-router-dom'
+import { useQuery } from 'react-apollo'
+import { get, last, capitalize, join, camelCase } from 'lodash'
 
-import { GET_CATEGORY_BY_TITLE } from './queries';
-import ContentSingle from '../../content-single';
-import { CardFeed } from '../../content-feed';
-import { Loader } from '../../ui';
+import { GET_CATEGORY_BY_TITLE } from './queries'
+import ContentSingle from '../../content-single'
+import { CardFeed } from '../../content-feed'
+import { Loader } from '../../ui'
 
 const ContentSingleWithRouter = ({ match: { params: { contentTitle = '' } = {} } } = {}) => {
-    const id = last(contentTitle.split('-'));
+    const id = last(contentTitle.split('-'))
     return (
         <ContentSingle
             itemId={`UniversalContentItem:${id}`}
         />
-    );
-};
+    )
+}
+
+const CardFeedWithRouter = ({ match: { params: { collectionTitle = '' } = {} } } = {}) => {
+    const id = last(collectionTitle.split('-'))
+    const capitalizeWords = collectionTitle.split('-').slice(0, -1).map( n => capitalize(n))
+    const title = join(capitalizeWords, ' ')
+
+    return (
+        <div
+            className="container-fluid"
+            style={{ minHeight: '100%' }}
+        >
+            <div className="row align-content-center mt-6 mb-n6">
+                <h3 className='col-10'>
+                    {title}
+                </h3>
+                <a 
+                 className='col-2 text-right'
+                 href='/'
+                >
+                    <h4>
+                        Go Back
+                    </h4>
+                </a>
+            </div>
+            <div className="row">
+                <CardFeed
+                    id={`UniversalContentItem:${id}`}
+                />           
+            </div>
+        </div>
+    )
+}
 
 const CategoryUrlMapper = ({ match: { params: { category } } }) => {
     const { loading, error, data } = useQuery(
         GET_CATEGORY_BY_TITLE,
         { variables: { title: category }, fetchPolicy: 'cache-and-network' },
-    );
+    )
 
-    if (loading) return <Loader />;
-    if (error) return null;
+    if (loading) return <Loader />
+    if (error) return null
 
-    const categoryData = get(data, 'getCategoryByTitle', {});
+    const categoryData = get(data, 'getCategoryByTitle', {})
 
     return (
         <div
@@ -44,18 +76,19 @@ const CategoryUrlMapper = ({ match: { params: { category } } }) => {
                 <CardFeed id={get(categoryData, 'id', '')} />
             </div>
         </div>
-    );
-};
+    )
+}
 
 const Router = () => (
     <Switch>
         <Route exact path="/content/categories/:category" component={CategoryUrlMapper} />
         <Route exact path="/content/:contentTitle" component={ContentSingleWithRouter} />
+        <Route exact path="/content/collection/:collectionTitle" component={CardFeedWithRouter} />
 
         <Route path="*">
             <Redirect to="/browse" />
         </Route>
     </Switch>
-);
+)
 
-export default Router;
+export default Router

--- a/src/router/Content/index.js
+++ b/src/router/Content/index.js
@@ -30,14 +30,14 @@ const CardFeedWithRouter = ({ match: { params: { collectionTitle = '' } = {} } }
             style={{ minHeight: '100%' }}
         >
             <div className="row align-content-center mt-6 mb-n6">
-                <h3 className='col-10'>
+                <h2 className='col-10'>
                     {title}
-                </h3>
+                </h2>
                 <a 
-                 className='col-2 text-right'
+                 className='col-2 text-right my-auto'
                  href='/'
                 >
-                    <h4>
+                    <h4 className='font-weight-normal mb-0'>
                         Go Back
                     </h4>
                 </a>


### PR DESCRIPTION
## Updated Router and ActionMapper
* Added **CardFeedWithRouter** component to Router. This renders a page with a single CardFeed and can be used for any collection/category of content.

* Updated **ActionMapper** case with `CHILD_TYPE` action to use `content/collection/` for the`urlBase`( _See More_ button).

* If collection title is "Popular Now",  _See More_ button will go to `/browse`