### PR TITLE
Fixed Invite Button Click Tracking

### DIFF
--- a/src/content-single/Banner/Share.js
+++ b/src/content-single/Banner/Share.js
@@ -76,19 +76,24 @@ const Share = ({
     <Dropdown
       drop="up"
       alignRight={false}
-      onClick={() => buttonClick(`${title} - Invite Button`, 'Open Share Sheet')}
     >
+      <a
+        onClick={() => buttonClick(`${title} - Invite Button`, 'Open Share Sheet')}
+      >
       <Dropdown.Toggle
         id={uniqueId('share-')}
         variant="ghost-white"
       >
-        <span className="mr-2">
+        <span 
+          className="mr-2"
+        >
           <FontAwesomeIcon
             icon={faShare}
           />
         </span>
         {shareTitle}
       </Dropdown.Toggle>
+      </a>
       <Dropdown.Menu>
         <Dropdown.Item
           target="_blank"


### PR DESCRIPTION
Was reading the Invite button click twice, when clicking on one of the following share buttons. Moved the buttonClick to read correctly.