### PR TITLE
Added HLS compatibility to Video player in Media Item

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "formik": "^1.5.8",
     "graphql": "^14.1.1",
     "graphql-tag": "^2.10.3",
+    "hls.js": "^0.13.2",
     "html-to-react": "^1.3.4",
     "jest-coverage-badges": "^1.1.2",
     "lodash": "^4.17.11",

--- a/src/ui/Media/MediaItem.js
+++ b/src/ui/Media/MediaItem.js
@@ -1,11 +1,13 @@
 import React, { createRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import { keys } from 'lodash';
+import { keys, includes } from 'lodash';
+import Hls from 'hls.js';
+
 
 import Image from './Image';
 import Video from './Video';
-import { PlayCircle } from '../Icons';
+import { Icon } from '../Icons';
 
 const MediaItem = ({
   ratio,
@@ -26,6 +28,8 @@ const MediaItem = ({
 }) => {
   const showVideoControls = showControls && !children;
   const [showPlayButton, setShowPlayButton] = useState(showVideoControls);
+
+
   const videoProps = showVideoControls
     ? {
       playsInline: false,
@@ -37,8 +41,20 @@ const MediaItem = ({
     : {};
   const videoRef = createRef();
 
+  const createHLSurl = () => {
+    let hls = new Hls({});
+    hls.loadSource(videoUrl);
+    hls.attachMedia(videoRef.current);
+    hls.on(Hls.Events.MANIFEST_PARSED, () => {
+          videoRef.current.play();
+    })
+  }
+
+
   const playButtonClick = () => {
-    videoRef.current.play();
+    const isHLS = videoUrl.includes('m3u8')
+     ? createHLSurl()
+     : videoRef.current.play();
     setShowPlayButton(false);
   };
   let ratioClass = typeof ratio === 'string'
@@ -112,7 +128,8 @@ const MediaItem = ({
                   className="btn btn-icon"
                   onClick={playButtonClick}
                 >
-                  <PlayCircle 
+                  <Icon
+                    name='play-circle' 
                     size={playIcon.size} 
                     fill={playIcon.color} 
                   />

--- a/src/ui/Media/Video.js
+++ b/src/ui/Media/Video.js
@@ -6,11 +6,21 @@ const MediaVideo = forwardRef((
     source,
     ...videoProps
   }, ref,
-) => (
-    <video {...videoProps} ref={ref} controlsList="nodownload">
-      <source type="video/mp4" src={source} />
-    </video>
-  ));
+) => {
+
+  return (
+      <video
+            {...videoProps} 
+            ref={ref}
+            controlsList="nodownload"
+            autoPlay={source.includes('m3u8')}
+          >
+            <source  
+              type='video/mp4' 
+              src={source} 
+            />
+        </video>
+  )});
 
 // Default state of the video is to be a silent,
 //  inline, looped video to be used like a background video


### PR DESCRIPTION
# Related Issue
- Added HLS compatibility to Video player in Media Item

# Changes or Updates
- imported `hls.js`
- added logic for HLS videos to play button in the **MediaItem.js**

# Tests
- [ ] needed snapshots updated
- [ ] mobile tested
- [ ] latest update from master
