### PR TITLE
Create apple-app-site-association

### DIFF
--- a/public/.well-known/apple-app-site-association
+++ b/public/.well-known/apple-app-site-association
@@ -1,0 +1,11 @@
+{
+  "applinks": {
+      "apps": [],
+      "details": [
+           {
+             "appID": "com.subsplashconsulting.BSVMPR",
+             "paths": [ "/content/*", "/items/*", "/events/*", ]
+           }
+       ]
+   }
+}


### PR DESCRIPTION
# Related Issue
- CFDP-668

# Changes or Updates
- Adds a specific public file according to Apple's [documentation](https://developer.apple.com/documentation/safariservices/supporting_associated_domains_in_your_app#3001215) around universal linking
- Follows the iOS 12 pattern because our app supports all the way back to iOS 9

# Tests
n/a
