### PR TITLE
[Bug] Remove duplicated video element

### DIFF
--- a/src/ui/Media/MediaItem.js
+++ b/src/ui/Media/MediaItem.js
@@ -61,23 +61,6 @@ const MediaItem = ({
         />
       )}
 
-      {videoUrl ? (
-        <Video
-          className={classnames('embed-responsive-item')}
-          source={videoUrl}
-          poster={imageUrl}
-          showControls={showControls}
-          isLive={isLive}
-          playIcon={playIcon}
-        />
-      ) : (
-        <Image
-          source={imageUrl}
-          alt={imageAlt}
-          className={classnames('embed-responsive-item')}
-        />
-      )}
-
       {!showControls && (
         <div
           className="fill d-flex justify-content-center align-items-center"


### PR DESCRIPTION

# Changes or Updates
For some inexplicable reason, the linting PR #147 duplicated the block of logic in **src/ui/Media/MediaItem.js** that adds the `<video>` element to the page ([diff](https://github.com/christfellowshipchurch/web-app/commit/9a5ae476f862611e09ed434a2e24ce20a8d6d79d#diff-0f51a94714e6be4f8c0c9e68f8a7ab80R47)).

This PR removes the extra `<video>`.

# Screenshots
|❌ Before|✅ After|
|---|---|
|![CleanShot 2020-09-09 at 14 40 30@2x](https://user-images.githubusercontent.com/1812955/92640281-0f679f00-f2ab-11ea-925e-e261f0f23fc4.jpg)|![CleanShot 2020-09-09 at 14 39 39@2x](https://user-images.githubusercontent.com/1812955/92640274-0c6cae80-f2ab-11ea-8b2d-bb7a92a018fc.jpg)|


# Tests
- [ ] needed snapshots updated
- [ ] mobile tested
- [ ] latest update from master
