### PR TITLE
Fix Group time not showing up on group card

### DIFF
--- a/src/groups/GroupListConnected/GroupList.js
+++ b/src/groups/GroupListConnected/GroupList.js
@@ -24,24 +24,21 @@ const GroupList = ({ isLoading, groups }) => (
   <LoadingState isLoading={isLoading}>
     {groups.length ? (
       <section className="row mx-n2">
-        {groups.map(
-          (n) =>
-            console.log(get(n, 'dateTime.start')) || (
-              <ContentCard
-                key={n.id}
-                urlBase="groups"
-                className="my-4"
-                id={n.id}
-                coverImage={get(n, 'coverImage.sources', '')}
-                title={get(n, 'title', '')}
-                label={{
-                  bg: 'dark',
-                  textColor: 'white',
-                  value: dateLabel(get(n, 'dateTime.start')),
-                }}
-              />
-            )
-        )}
+        {groups.map((n) => (
+          <ContentCard
+            key={n.id}
+            urlBase="groups"
+            className="my-4"
+            id={n.id}
+            coverImage={get(n, 'coverImage.sources', '')}
+            title={get(n, 'title', '')}
+            label={{
+              bg: 'dark',
+              textColor: 'white',
+              value: dateLabel(get(n, 'dateTime.start')),
+            }}
+          />
+        ))}
       </section>
     ) : (
       <p className="pt-2">

--- a/src/groups/GroupListConnected/dateLabel.js
+++ b/src/groups/GroupListConnected/dateLabel.js
@@ -19,7 +19,7 @@ const dateLabel = (date) => {
     label = mDate.format('MMM DD, YYYY');
   } else {
     /** If the date is within this year: January 1 */
-    label = mDate.format('MMMM DD');
+    label = mDate.format('MMMM DD [at] h:mm A');
   }
 
   return label;


### PR DESCRIPTION
# Changes or Updates
- fixes group cards (seen on `/groups`) with dates starting in the next week not showing a time. 

![Sep-17-2020 11-16-49](https://user-images.githubusercontent.com/2053547/93491185-64bd3500-f8d7-11ea-9c93-e46b844ae1a7.gif)


# Tests
- [x] mobile tested
- [x] latest update from master
