### PR TITLE
Use nicknames in groups

### DIFF
--- a/src/groups/GroupContentItemConnected/GroupContentItem.js
+++ b/src/groups/GroupContentItemConnected/GroupContentItem.js
@@ -193,15 +193,4 @@ GroupContentItem.propTypes = {
   }),
 };
 
-GroupContentItem.defaultProps = {
-  coverImage: {
-    sources: [
-      {
-        uri:
-          'https://rock.christfellowship.church/Content/ExternalSite/Banners/GroupsHeader.jpg',
-      },
-    ],
-  },
-};
-
 export default GroupContentItem;

--- a/src/groups/GroupContentItemConnected/getGroup.js
+++ b/src/groups/GroupContentItemConnected/getGroup.js
@@ -49,6 +49,7 @@ export default gql`
       profile {
         id
         firstName
+        nickName
       }
     }
   }

--- a/src/groups/GroupContentItemConnected/index.js
+++ b/src/groups/GroupContentItemConnected/index.js
@@ -95,7 +95,10 @@ const GroupContentItemConnected = ({ itemId }) => {
       parentVideoCall={get(content, 'parentVideoCall')}
       summary={get(content, 'summary')}
       title={get(content, 'title')}
-      userName={get(data, 'currentUser.profile.firstName')}
+      userName={
+        get(data, 'currentUser.profile.nickName') ||
+        get(data, 'currentUser.profile.firstName')
+      }
       videoCall={get(content, 'videoCall')}
     />
   );


### PR DESCRIPTION
# Changes or Updates
- prefers user nickName to firstName when setting your zoom username when you join a meeting
- removes default groups photo as this is now driven by rock

👇 note that this users name is `A` and its nickname is `Marty`. When you join the zoom call it set the user name to `Marty`.
![Sep-17-2020 11-07-27](https://user-images.githubusercontent.com/2053547/93490123-165b6680-f8d6-11ea-993c-d9920064121d.gif)


# Tests
- [x] mobile tested
- [x] latest update from master
