### PR TITLE
Updated Groups query for DreamTeams

### DIFF
--- a/src/groups/GroupListConnected/getCurrentUserGroups.js
+++ b/src/groups/GroupListConnected/getCurrentUserGroups.js
@@ -6,18 +6,17 @@ export default gql`
       id
       profile {
         id
-        groups {
+        groups(input: { excludeTypes: [DreamTeam] }) {
           ... on Group {
             id
             dateTime {
               start
-              end
             }
-            title
-            coverImage {
-              sources {
-                uri
-              }
+          }
+          title
+          coverImage {
+            sources {
+              uri
             }
           }
         }


### PR DESCRIPTION
# Related Issue
- Updated `getCurrentUserGroup` query to work with upcoming `my-dream-teams-feature` update on the `apollos-api`

# Changes or Updates
- Updated queries
