### PR TITLE
[Chat] Fix user role logic and message actions

### DIFF
--- a/src/content-single/EventContentItem/components/EventPanel.js
+++ b/src/content-single/EventContentItem/components/EventPanel.js
@@ -64,8 +64,8 @@ const EventPanel = ({ event, channelId }) => {
   const [activeTab, setActiveTabIndex] = useState('chat');
   const [watcherCount, setWatcherCount] = useState(null);
 
-  const handleWatcherCountChange = (num) => {
-    setWatcherCount(numeral(num).format('0,0'));
+  const handleWatcherCountChange = (num = 0) => {
+    setWatcherCount(numeral(num + 1).format('0,0'));
   };
 
   return (

--- a/src/stream-chat-client/chatRoles.js
+++ b/src/stream-chat-client/chatRoles.js
@@ -1,5 +1,6 @@
 const ChatRoles = Object.freeze({
   USER: 'USER',
+  MEMBER: 'USER', // Treat 'user' and 'member' as the same thing
   MODERATOR: 'MODERATOR',
   GUEST: 'GUEST',
 });

--- a/src/stream-chat-client/chatUtils.js
+++ b/src/stream-chat-client/chatUtils.js
@@ -24,16 +24,17 @@ export function getStreamUser(user) {
 
 export function getRoleFromMembership(channel) {
   const role = get(channel, 'state.user.role');
+  const membership = get(channel, 'state.membership.user.role');
 
-  if (!role) {
+  if (!(role || membership)) {
     return ChatRoles.GUEST;
   }
 
   // ⚠️ Warning
   // There is an assumption that stream's role names will map 1:1
-  // with the ones we use in our graphql API's enum.
+  // with the ones we use in our graphql API enum.
   // i.e. "moderator" in Stream is "MODERATOR" in our API.
-  return ChatRoles[role.toUpperCase()];
+  return ChatRoles[(role || membership).toUpperCase()];
 }
 
 // :: Channel

--- a/src/stream-chat-client/chatUtils.js
+++ b/src/stream-chat-client/chatUtils.js
@@ -23,7 +23,7 @@ export function getStreamUser(user) {
 }
 
 export function getRoleFromMembership(channel) {
-  const role = get(channel, 'state.membership.role');
+  const role = get(channel, 'state.user.role');
 
   if (!role) {
     return ChatRoles.GUEST;

--- a/src/ui/chat/getMessageActionOptions.js
+++ b/src/ui/chat/getMessageActionOptions.js
@@ -20,7 +20,7 @@ export default function getMessageActionOptions({
 }) {
   const isModerator = userRole === ChatRoles.MODERATOR;
   const isMine = isMyMessage();
-  const showSendDirectMessage = !isMine && !!onInitiateDm;
+  const showSendDirectMessage = isModerator && !isMine && !!onInitiateDm;
 
   return [
     {
@@ -46,7 +46,7 @@ export default function getMessageActionOptions({
     },
     {
       label: 'Delete Message',
-      showWhen: isMyMessage || isModerator,
+      showWhen: isMine || isModerator,
       destructive: true,
       callback: handleDelete,
     },


### PR DESCRIPTION
# Related Issue
- [**🏕 [Chat] Bug: All users are considered moderators**](https://3.basecamp.com/3926363/buckets/17566548/todos/3115301414)

# Changes or Updates
- Fix the logic util that determines a users' role from `channel` data, to prevent bug where users were always considered moderators
- Fix subtle bug where _Delete Message_ action was always available regardless
- Always add one to the watcher count, to account for the current user and prevent 0

Here's the expected message actions for various scenarios.
**Guest** role has _no available actions_, so is not included in the table.

|Action|My Messages|Others' Messages:<br />👤 `USER` Role|Others' Messages:<br />👮‍♀️ `MODERATOR` Role|
|---|---|---|---|
|**📫 Send DM**|✖️|✖️|✅|
|**🚩 Flag Message**|✖️|✅|✅|
|**🔇 Mute Person**|✖️|✅|✅|
|**🗑️ Delete Message**|✅|✅|✅|
|**🚫 Ban Person**|✖️|✖️|✅|

# Test Instructions

⚠️ **NOTE** ⚠️
You'll need to use api branch `moderator-group` to review this, if [apollos-api > PR 139](https://github.com/christfellowshipchurch/apollos-api/pull/139) has not been merged yet.

- Verify the actions above are correctly available for each of the user roles — `guest` (logged out), `user`, `moderator`.
- Your "real" Differential email account should have `moderator` role, and the Star Wars test accounts should be regular `user` role.

# Screenshots
|👀 Guest|👤 User|👮‍♀️ Moderator|
|---|---|---|
|![2020-10-14 20 01 35](https://user-images.githubusercontent.com/1812955/96058740-0ba2db80-0e5a-11eb-8696-1c66da615d7c.gif)|![2020-10-14 20 02 07](https://user-images.githubusercontent.com/1812955/96058743-10678f80-0e5a-11eb-9613-63b00f09f863.gif)|![2020-10-14 20 00 24](https://user-images.githubusercontent.com/1812955/96058750-1493ad00-0e5a-11eb-823b-81e7d924329c.gif)|

# Tests
- [ ] needed snapshots updated
- [ ] mobile tested
- [ ] latest update from master
