### PR TITLE
Fix minimize theater mode icon

### DIFF
--- a/src/content-single/EventContentItem/EventLiveLayout.js
+++ b/src/content-single/EventContentItem/EventLiveLayout.js
@@ -70,7 +70,11 @@ const EventLiveLayout = ({ contentId, content, liveStream }) => {
       {theaterMode ? (
         <TheaterContainer>
           <Area area="stream">
-            <EventMedia {...content} liveStreamSource={liveStreamSource} />
+            <EventMedia
+              {...content}
+              liveStreamSource={liveStreamSource}
+              showTheaterMode={theaterMode}
+            />
           </Area>
           <Area area="heading">
             <EventHeading {...content} isLive />

--- a/src/ui/Media/Video.js
+++ b/src/ui/Media/Video.js
@@ -167,6 +167,7 @@ const MediaVideo = ({ source, poster, isLive, showControls, showTheaterMode }) =
             top: 0,
             right: 0,
             padding: '0.75rem',
+            cursor: 'pointer',
           }}
         >
           <Icon


### PR DESCRIPTION
Icon wasn't showing up probably due to a merge conflict at some point. This fixes that.

![image](https://user-images.githubusercontent.com/877100/98970638-2b233780-24de-11eb-8835-a10393cab7d2.png)
