### PR TITLE
Updated Fetch Polices for Page Builder

### DIFF
--- a/src/page-builder/Standard.js
+++ b/src/page-builder/Standard.js
@@ -20,6 +20,7 @@ const DefaultPage = ({ title }) => {
 
   const { loading, error, data } = useQuery(GET_BLOCK_ITEMS, {
     variables: { website, title },
+    fetchPolicy: 'cache-and-network',
   });
 
   if (loading) {

--- a/src/page-builder/Swoop.js
+++ b/src/page-builder/Swoop.js
@@ -86,6 +86,7 @@ const Swoop = ({ title, backgroundColors, backgroundImages, swoopTypes }) => {
   const website = process.env.REACT_APP_WEBSITE_KEY;
   const { loading, error, data } = useQuery(GET_BLOCK_ITEMS, {
     variables: { website, title },
+    fetchPolicy: 'cache-and-network',
   });
 
   if (loading) {


### PR DESCRIPTION
# Related Issue
- No fetch policies were set for the PageBuilder pages. Therefore, we were having caching issues.

# Changes or Updates
- Updated fetch policy for PageBuilder to use `cache-and-network`

