### PR TITLE
[CFDP-1113] Interaction Component from Apollos

### DIFF
--- a/src/content-single/index.js
+++ b/src/content-single/index.js
@@ -62,7 +62,11 @@ const ContentSingle = ({ itemId }) => {
 
   return (
     <>
-      <InteractWhenLoadedConnected isLoading={loading} nodeId={itemId} action={`VIEW`} />
+      <InteractWhenLoadedConnected
+        isLoading={loading}
+        nodeId={itemId}
+        action={`COMPLETE`}
+      />
       <Metadata
         tags={uniqBy(
           [

--- a/src/content-single/index.js
+++ b/src/content-single/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { useQuery } from 'react-apollo';
-import { get, uniqBy } from 'lodash';
+import { get, uniqBy, isEmpty } from 'lodash';
 
 import Metadata from '../metadata';
 import { InteractWhenLoadedConnected, TrackEventWhenLoaded } from '../ui-connected';
@@ -14,6 +14,7 @@ const ContentSingle = ({ itemId }) => {
   const { loading, error, data } = useQuery(GET_CONTENT_ITEM, {
     variables: {
       itemId,
+      skip: !itemId || isEmpty(itemId),
     },
     fetchPolicy: 'cache-and-network',
   });
@@ -60,6 +61,13 @@ const ContentSingle = ({ itemId }) => {
     }
   };
 
+  const trackLoaded =
+    !!itemId &&
+    !loading &&
+    !isEmpty(itemId) &&
+    !!content.id &&
+    !(String(window.performance.getEntriesByType('navigation')[0].type) === 'reload');
+
   return (
     <>
       <InteractWhenLoadedConnected
@@ -68,7 +76,7 @@ const ContentSingle = ({ itemId }) => {
         action={`COMPLETE`}
       />
       <TrackEventWhenLoaded
-        loaded={!!(!loading && content.title)}
+        loaded={trackLoaded}
         eventName={'View Content'}
         properties={{
           title: content.title,

--- a/src/content-single/index.js
+++ b/src/content-single/index.js
@@ -4,6 +4,7 @@ import { useQuery } from 'react-apollo';
 import { get, uniqBy } from 'lodash';
 
 import Metadata from '../metadata';
+import { InteractWhenLoadedConnected } from '../ui-connected';
 import { GET_CONTENT_ITEM } from './queries';
 import UniversalContentItem from './UniversalContentItem';
 import EventContentItem from './EventContentItem';
@@ -61,6 +62,7 @@ const ContentSingle = ({ itemId }) => {
 
   return (
     <>
+      <InteractWhenLoadedConnected isLoading={loading} nodeId={itemId} action={`VIEW`} />
       <Metadata
         tags={uniqBy(
           [

--- a/src/content-single/index.js
+++ b/src/content-single/index.js
@@ -4,7 +4,7 @@ import { useQuery } from 'react-apollo';
 import { get, uniqBy } from 'lodash';
 
 import Metadata from '../metadata';
-import { InteractWhenLoadedConnected } from '../ui-connected';
+import { InteractWhenLoadedConnected, TrackEventWhenLoaded } from '../ui-connected';
 import { GET_CONTENT_ITEM } from './queries';
 import UniversalContentItem from './UniversalContentItem';
 import EventContentItem from './EventContentItem';
@@ -66,6 +66,14 @@ const ContentSingle = ({ itemId }) => {
         isLoading={loading}
         nodeId={itemId}
         action={`COMPLETE`}
+      />
+      <TrackEventWhenLoaded
+        loaded={!!(!loading && content.title)}
+        eventName={'View Content'}
+        properties={{
+          title: content.title,
+          itemId,
+        }}
       />
       <Metadata
         tags={uniqBy(

--- a/src/ui-connected/InteractWhenLoadedConnected/InteractWhenLoadedConnected.tests.js
+++ b/src/ui-connected/InteractWhenLoadedConnected/InteractWhenLoadedConnected.tests.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import { Providers, renderWithApolloData } from '../testUtils';
+import InteractWhenLoadedConnected from '.';
+
+describe('The InteractWhenLoadedConnected component', () => {
+  it('should render with isLoading=false', async () => {
+    const tree = await renderWithApolloData(
+      <Providers>
+        <InteractWhenLoadedConnected
+          isLoading={false}
+          action="COMPLETE"
+          nodeId="UniversalContentItem:123"
+        />
+      </Providers>
+    );
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('should render with isLoading=true', async () => {
+    const tree = await renderWithApolloData(
+      <Providers>
+        <InteractWhenLoadedConnected
+          isLoading
+          action="COMPLETE"
+          nodeId="UniversalContentItem:123"
+        />
+      </Providers>
+    );
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/src/ui-connected/InteractWhenLoadedConnected/__snapshots__/InteractWhenLoadedConnected.tests.js.snap
+++ b/src/ui-connected/InteractWhenLoadedConnected/__snapshots__/InteractWhenLoadedConnected.tests.js.snap
@@ -1,0 +1,5 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`The InteractWhenLoadedConnected component should render with isLoading=false 1`] = `null`;
+
+exports[`The InteractWhenLoadedConnected component should render with isLoading=true 1`] = `null`;

--- a/src/ui-connected/InteractWhenLoadedConnected/index.js
+++ b/src/ui-connected/InteractWhenLoadedConnected/index.js
@@ -1,0 +1,48 @@
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import { Mutation } from 'react-apollo';
+import INTERACT_WITH_NODE from './interactWithNode';
+
+class InteractWhenLoaded extends PureComponent {
+  componentDidMount() {
+    if (!this.props.isLoading) {
+      this.interact();
+    }
+  }
+
+  componentDidUpdate(prevProps) {
+    if (prevProps.isLoading && !this.props.isLoading) {
+      this.interact();
+    }
+  }
+
+  interact() {
+    return this.props.mutate();
+  }
+
+  render() {
+    return null;
+  }
+}
+
+InteractWhenLoaded.propTypes = {
+  isLoading: PropTypes.bool.isRequired,
+  // properties: PropTypes.any,
+  mutate: PropTypes.func.isRequired,
+};
+
+const InteractWhenLoadedConnected = (props) => (
+  <Mutation
+    mutation={INTERACT_WITH_NODE}
+    variables={{ nodeId: props.nodeId, action: props.action }}
+  >
+    {(mutate) => <InteractWhenLoaded {...props} mutate={mutate} />}
+  </Mutation>
+);
+
+InteractWhenLoadedConnected.propTypes = {
+  nodeId: PropTypes.string,
+  action: PropTypes.string.isRequired,
+};
+
+export default InteractWhenLoadedConnected;

--- a/src/ui-connected/InteractWhenLoadedConnected/index.js
+++ b/src/ui-connected/InteractWhenLoadedConnected/index.js
@@ -1,6 +1,7 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { Mutation } from 'react-apollo';
+import { useAuth } from 'auth';
 import INTERACT_WITH_NODE from './interactWithNode';
 
 class InteractWhenLoaded extends PureComponent {
@@ -31,14 +32,20 @@ InteractWhenLoaded.propTypes = {
   mutate: PropTypes.func.isRequired,
 };
 
-const InteractWhenLoadedConnected = (props) => (
-  <Mutation
-    mutation={INTERACT_WITH_NODE}
-    variables={{ nodeId: props.nodeId, action: props.action }}
-  >
-    {(mutate) => <InteractWhenLoaded {...props} mutate={mutate} />}
-  </Mutation>
-);
+const InteractWhenLoadedConnected = (props) => {
+  const { isLoggedIn } = useAuth();
+
+  if (!isLoggedIn) return null;
+
+  return (
+    <Mutation
+      mutation={INTERACT_WITH_NODE}
+      variables={{ nodeId: props.nodeId, action: props.action }}
+    >
+      {(mutate) => <InteractWhenLoaded {...props} mutate={mutate} />}
+    </Mutation>
+  );
+};
 
 InteractWhenLoadedConnected.propTypes = {
   nodeId: PropTypes.string,

--- a/src/ui-connected/InteractWhenLoadedConnected/index.sandbox.js
+++ b/src/ui-connected/InteractWhenLoadedConnected/index.sandbox.js
@@ -1,0 +1,47 @@
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import { Mutation } from 'react-apollo';
+import INTERACT_WITH_NODE from './interactWithNode';
+
+class InteractWhenLoaded extends PureComponent {
+  componentDidMount() {
+    if (!this.props.isLoading) {
+      this.interact();
+    }
+  }
+
+  componentDidUpdate(prevProps) {
+    if (prevProps.isLoading && !this.props.isLoading) {
+      this.interact();
+    }
+  }
+
+  //disable tracking for beta
+  interact() {
+    return null;
+  }
+
+  render() {
+    return null;
+  }
+}
+
+InteractWhenLoaded.propTypes = {
+  isLoading: PropTypes.bool.isRequired,
+  // properties: PropTypes.any,
+  mutate: PropTypes.func.isRequired,
+};
+
+const InteractWhenLoadedConnected = (props) => {
+  // ---- NOTE ----
+  // In order to track more accurate interactions,
+  // we want to disable tracking for our beta site
+  return null;
+};
+
+InteractWhenLoadedConnected.propTypes = {
+  nodeId: PropTypes.string,
+  action: PropTypes.string.isRequired,
+};
+
+export default InteractWhenLoadedConnected;

--- a/src/ui-connected/InteractWhenLoadedConnected/interactWithNode.js
+++ b/src/ui-connected/InteractWhenLoadedConnected/interactWithNode.js
@@ -1,0 +1,9 @@
+import gql from 'graphql-tag';
+
+export default gql`
+  mutation interactWithNode($nodeId: ID!, $action: InteractionAction!) {
+    interactWithNode(nodeId: $nodeId, action: $action) {
+      success
+    }
+  }
+`;

--- a/src/ui-connected/TrackEventWhenLoaded/index.js
+++ b/src/ui-connected/TrackEventWhenLoaded/index.js
@@ -1,7 +1,9 @@
 import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { useMutation } from 'apollo-client';
+import { useMutation } from 'react-apollo';
 import gql from 'graphql-tag';
+
+import { useAuth } from 'auth';
 
 const TRACK = gql`
   mutation track($input: AnalyticsTrackInput!) {
@@ -19,17 +21,20 @@ const objectToGqlInput = (props = {}) =>
 
 const TrackEventWhenLoadedConnected = ({ loaded, eventName, properties }) => {
   const [track] = useMutation(TRACK);
+  const { isLoggedIn } = useAuth();
 
   useEffect(() => {
-    if (loaded) {
+    if (loaded && isLoggedIn) {
       track({
         variables: {
-          eventName,
-          properties: objectToGqlInput(properties),
+          input: {
+            eventName,
+            properties: objectToGqlInput(properties),
+          },
         },
       });
     }
-  }, [loaded]);
+  }, [loaded, isLoggedIn]);
 
   return null;
 };

--- a/src/ui-connected/TrackEventWhenLoaded/index.js
+++ b/src/ui-connected/TrackEventWhenLoaded/index.js
@@ -4,8 +4,10 @@ import { useMutation } from 'apollo-client';
 import gql from 'graphql-tag';
 
 const TRACK = gql`
-  mutation track($properties: [AnalyticsMetaField]!, $eventName: String!) {
-    track(properties: $properties, eventName: $eventName) @client
+  mutation track($input: AnalyticsTrackInput!) {
+    trackEvent(input: $input) {
+      success
+    }
   }
 `;
 

--- a/src/ui-connected/TrackEventWhenLoaded/index.js
+++ b/src/ui-connected/TrackEventWhenLoaded/index.js
@@ -1,0 +1,42 @@
+import React, { useEffect } from 'react';
+import PropTypes from 'prop-types';
+import { useMutation } from 'apollo-client';
+import gql from 'graphql-tag';
+
+const TRACK = gql`
+  mutation track($properties: [AnalyticsMetaField]!, $eventName: String!) {
+    track(properties: $properties, eventName: $eventName) @client
+  }
+`;
+
+const objectToGqlInput = (props = {}) =>
+  Object.keys(props).map((key) => ({
+    field: key,
+    value: props[key],
+  }));
+
+const TrackEventWhenLoadedConnected = ({ loaded, eventName, properties }) => {
+  const [track] = useMutation(TRACK);
+
+  useEffect(() => {
+    if (loaded) {
+      track({
+        variables: {
+          eventName,
+          properties: objectToGqlInput(properties),
+        },
+      });
+    }
+  }, [loaded]);
+
+  return null;
+};
+
+TrackEventWhenLoadedConnected.propTypes = {
+  loaded: PropTypes.bool,
+  eventName: PropTypes.string.isRequired,
+  // eslint-disable-next-line react/forbid-prop-types
+  properties: PropTypes.any,
+};
+
+export default TrackEventWhenLoadedConnected;

--- a/src/ui-connected/index.js
+++ b/src/ui-connected/index.js
@@ -4,8 +4,10 @@ import PageBuilderConnected, {
 } from './PageBuilderConnected';
 
 import InteractWhenLoadedConnected from './InteractWhenLoadedConnected';
+import TrackEventWhenLoaded from './TrackEventWhenLoaded';
 
 export {
+  TrackEventWhenLoaded,
   InteractWhenLoadedConnected,
   PageBuilderConnected,
   pageBuilderComponentMapper,

--- a/src/ui-connected/index.js
+++ b/src/ui-connected/index.js
@@ -3,4 +3,11 @@ import PageBuilderConnected, {
   GET_PAGE_BUILDER_FEATURES,
 } from './PageBuilderConnected';
 
-export { PageBuilderConnected, pageBuilderComponentMapper, GET_PAGE_BUILDER_FEATURES };
+import InteractWhenLoadedConnected from './InteractWhenLoadedConnected';
+
+export {
+  InteractWhenLoadedConnected,
+  PageBuilderConnected,
+  pageBuilderComponentMapper,
+  GET_PAGE_BUILDER_FEATURES,
+};


### PR DESCRIPTION
# Related Issue
- We want to track interactions with content items like we are on the mobile app.

# Changes or Updates
- added `InteractWhenLoadedConnected` component from Apollos to `/ui-connected`
- added tracking to `content-single`

### To Do
- Right now Rock is only seeing the content item Id and the action. Need to find how the app is able to add title and other labels.

# Tests
- [x] needed snapshots updated
- [x] mobile tested
- [x] latest update from master
