### PR TITLE
Removed sort method from Groups

### DIFF
--- a/src/groups/GroupListConnected/index.js
+++ b/src/groups/GroupListConnected/index.js
@@ -18,9 +18,10 @@ const GroupListConnected = () => {
   }
 
   // Sort groups by date. TDOD: move this to the API
-  const groups = get(data, 'currentUser.profile.groups', []).sort((a, b) =>
-    moment(a.dateTime.start).diff(b.dateTime.start)
-  );
+  // const groups = get(data, 'currentUser.profile.groups', []).sort((a, b) =>
+  //   moment(a.dateTime.start).diff(b.dateTime.start)
+  // );
+  const groups = get(data, 'currentUser.profile.groups', []);
 
   return <GroupList isLoading={loading} groups={groups} />;
 };


### PR DESCRIPTION
# Related Issue
- Certain groups when sorted by date are causing the website to error out when loading current users Group List.

# Changes/Update
- Removed sort method from `GroupListConnected`