### PR TITLE
Disabled swoop inside of page builder

### DIFF
--- a/src/page-builder/Standard.js
+++ b/src/page-builder/Standard.js
@@ -43,7 +43,7 @@ const DefaultPage = ({ title }) => {
   );
 
   return (
-    <div className="container-fluid">
+    <div className="w-100">
       {blockItems.map((item, i) => {
         const id = lowerCase(get(item, 'title', '')).replace(/\s/g, '-');
         const bg = bgColor[`${bgIndex}`];
@@ -89,7 +89,7 @@ const DefaultPage = ({ title }) => {
         }
 
         return (
-          <div id={id} className={`row ${bg}`} key={i}>
+          <div id={id} className={`p-relative overflow-hidden ${bg}`} key={i}>
             {content}
           </div>
         );

--- a/src/page-builder/index.js
+++ b/src/page-builder/index.js
@@ -5,12 +5,13 @@ import Swoop from './Swoop';
 import Standard from './Standard';
 
 const PageBuilder = ({ theme, ...props }) => {
-  switch (theme) {
-    case 'swoop':
-      return <Swoop {...props} />;
-    default:
-      return <Standard {...props} />;
-  }
+  // switch (theme) {
+  //   case 'swoop':
+  //     return <Swoop {...props} />;
+  //   default:
+  //     return <Standard {...props} />;
+  // }
+  return <Standard {...props} />;
 };
 
 PageBuilder.propTypes = {


### PR DESCRIPTION
# Related Issue
- Disabled Swoop for Page Builder

# Changes or Updates
- Commented out `Swoop` component so it only used the `Standard` Page Builder component.
